### PR TITLE
Implement Docker Registry API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,9 @@ val cSource = SettingKey[File]("c-source")
 val Versions = new {
   val argonaut = "6.3-SNAPSHOT"
   val scala    = "2.11.11"
+  val scalaz   = "7.2.16"
   val scopt    = "3.7.0"
+  val slogging = "0.6.0"
   val utest    = "0.5.3"
 }
 
@@ -90,8 +92,10 @@ lazy val cli = project
   .settings(commonSettings)
   .settings(Seq(
     libraryDependencies ++= Seq(
-      "com.github.scopt"  %%% "scopt"    % Versions.scopt,
-      "io.argonaut"       %%% "argonaut" % Versions.argonaut
+      "com.github.scopt"  %%% "scopt"       % Versions.scopt,
+      "io.argonaut"       %%% "argonaut"    % Versions.argonaut,
+      "biz.enef"          %%% "slogging"    % Versions.slogging,
+      "org.scalaz"        %%% "scalaz-core" % Versions.scalaz
     )
   ))
   .settings(

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/Config.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/Config.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import argonaut._
+
+import Argonaut._
+
+case class Config(config: Config.Cfg)
+
+object Config {
+  case class Cfg(
+    Hostname: Option[String] = None,
+    ExposedPorts: Option[Map[String, Map[String, String]]] = None,
+    Cmd: Option[Vector[String]] = None,
+    Image: Option[String] = None,
+    User: Option[String] = None,
+    Labels: Option[Map[String, String]] = None)
+
+  implicit val cfgCodec: CodecJson[Cfg] = CodecJson.derive[Cfg]
+  implicit val configCodec: CodecJson[Config] = CodecJson.derive[Config]
+}

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli
+package docker
+
+import argonaut._
+import libhttpsimple._
+import scala.util.{ Failure, Success, Try }
+import scalaz._
+import slogging._
+
+import Argonaut._
+import Scalaz._
+
+object DockerRegistry extends LazyLogging {
+  def blobUrl(img: Image, digest: String): String =
+    s"https://${img.url}/v2/${img.namespace}/${img.image}/blobs/$digest"
+
+  def manifestUrl(img: Image): String =
+    s"https://${img.url}/v2/${img.namespace}/${img.image}/manifests/${img.tag}"
+
+  def parseImageUri(uri: String): Try[Image] = {
+    val parts = uri.split("/", 3).toVector
+
+    val providedUrl = (parts.length > 2).option(parts(0))
+
+    val providedNs = (parts.length > 2).option(parts(1))
+      .orElse((parts.length > 1).option(parts(0)))
+
+    val imageParts = (parts.length > 2).option(parts(2))
+      .orElse((parts.length > 1).option(parts(1)))
+      .getOrElse(parts(0))
+      .split(":", 2)
+
+    val image = imageParts(0)
+
+    val providedTag = (imageParts.length > 1).option(imageParts(1))
+
+    if (image.isEmpty || providedTag.fold(false)(_.isEmpty))
+      Failure(new IllegalArgumentException(s"""Cannot parse uri "$uri"""))
+    else
+      Success(
+        Image(
+          url = providedUrl.getOrElse(DockerDefaultRegistry),
+          namespace = providedNs.getOrElse(DockerDefaultLibrary),
+          image = image,
+          tag = providedTag.getOrElse(DockerDefaultTag),
+          providedUrl = providedUrl,
+          providedNamespace = providedNs,
+          providedImage = image,
+          providedTag = providedTag))
+  }
+
+  def getBlob(uri: String, digest: String, token: Option[String]): Try[(HttpResponse, Option[String])] =
+    for {
+      i <- parseImageUri(uri)
+      r <- getWithToken(blobUrl(i, digest), HttpHeaders(Map.empty), token = token)
+    } yield r
+
+  def getConfig(uri: String, token: Option[String]): Try[(Config, Option[String])] =
+    for {
+      manifest <- getManifest(uri, token)
+      blob <- getBlob(uri, manifest._1.config.digest, token = manifest._2)
+      config <- getDecoded[Config](blob._1)
+    } yield config -> blob._2
+
+  def getDecoded[T](response: HttpResponse)(implicit decode: DecodeJson[T]): Try[T] =
+    if (response.statusCode == 200)
+      response.body.getOrElse("").decodeEither[T].fold(
+        err => Failure(new IllegalArgumentException(s"Decode Failure: $err")),
+        Success.apply)
+    else
+      Failure(new IllegalArgumentException(s"Expected code 200, received ${response.statusCode}"))
+
+  def getManifest(uri: String, token: Option[String]): Try[(Manifest, Option[String])] =
+    for {
+      i <- parseImageUri(uri)
+      r <- getWithToken(manifestUrl(i), HttpHeaders(Map("Accept" -> DockerAcceptManifestHeader)), token = token)
+      v <- getDecoded[Manifest](r._1)
+    } yield v -> r._2
+
+  private def getWithToken(url: String, headers: HttpHeaders, tryNewToken: Boolean = true, token: Option[String] = None): Try[(HttpResponse, Option[String])] = {
+    val request =
+      HttpRequest(url)
+        .headers(token.fold(headers)(t => headers.updated("Authorization", s"Bearer $t")))
+        .enableFollowRedirects
+
+    LibHttpSimple(request).flatMap {
+      case response if response.statusCode == 401 && response.headers.contains("Www-Authenticate") && tryNewToken =>
+        logger.debug("Received 401, attempting to get a token and try again")
+
+        val authenticateHeader = response.headers("Www-Authenticate")
+
+        val maybeResponse =
+          for {
+            realm <- parseWwwAuthenticate(authenticateHeader, "realm")
+            service <- parseWwwAuthenticate(authenticateHeader, "service")
+            scope <- parseWwwAuthenticate(authenticateHeader, "scope")
+            tokenResponse <- LibHttpSimple(HttpRequest(tokenUrl(realm, service, scope, "LightbendReactiveCLI"))).toOption
+
+            if tokenResponse.statusCode == 200
+
+            body <- tokenResponse.body
+            json <- JsonParser.parse(body).right.toOption
+            token <- json.field("token")
+            tokenStr <- token.string
+          } yield getWithToken(url, headers, tryNewToken = false, token = Some(tokenStr))
+
+        maybeResponse.getOrElse {
+          logger.error(s"Unable to obtain an OAuth token (${response.statusCode}${response.body.fold("")(" " + _)})")
+          logger.debug(response.toString)
+          Success(response -> token)
+        }
+
+      case response =>
+        Success(response -> token)
+    }
+  }
+
+  /* @TODO need a URL query library */
+  private def tokenUrl(realm: String, service: String, scope: String, clientId: String) =
+    s"$realm?service=$service&scope=$scope&client_id=$clientId"
+
+  /* @TODO need a more robust parser */
+  def parseWwwAuthenticate(authenticate: String, section: String): Option[String] =
+    (section + "=\"([^\"]+)\"")
+      .r
+      .findFirstMatchIn(authenticate)
+      .flatMap(_.subgroups.headOption)
+}

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+case class Image(
+  url: String,
+  namespace: String,
+  image: String,
+  tag: String,
+  providedUrl: Option[String],
+  providedNamespace: Option[String],
+  providedImage: String,
+  providedTag: Option[String])

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/Manifest.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/Manifest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import argonaut._
+
+import Argonaut._
+
+case class Manifest(
+  schemaVersion: Int,
+  mediaType: String,
+  config: Manifest.Layer,
+  layers: Vector[Manifest.Layer])
+
+object Manifest {
+  case class Layer(mediaType: String, size: Int, digest: String)
+
+  implicit val layerCodec: CodecJson[Layer] = CodecJson.derive[Layer]
+  implicit val manifestCodec: CodecJson[Manifest] = CodecJson.derive[Manifest]
+}

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/package.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli
+
+package object docker {
+  val DockerAcceptManifestHeader = "application/vnd.docker.distribution.manifest.v2+json"
+  val DockerDefaultRegistry = "registry.hub.docker.com"
+  val DockerDefaultLibrary = "library"
+  val DockerDefaultTag = "latest"
+}

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/ConfigTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/ConfigTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import argonaut._
+import utest._
+
+import Argonaut._
+case class Cfg(
+  Hostname: Option[String] = None,
+  ExposedPorts: Option[Map[String, String]] = None,
+  Cmd: Option[Vector[String]] = None,
+  Image: Option[String] = None,
+  User: Option[String] = None,
+  Labels: Option[Map[String, String]] = None)
+object ConfigTest extends TestSuite {
+  val tests = this{
+    "Decode JSON" - {
+      assert(
+        """{}""""
+          .decodeOption[Config]
+          .isEmpty)
+
+      assert(
+        """{ "config": {} }"""
+          .decodeOption[Config]
+          .contains(Config(Config.Cfg())))
+
+      assert(
+        """|{
+           |  "config": {
+           |    "Labels": {
+           |      "test.one": "test one!",
+           |      "test.two": "test two!"
+           |    },
+           |    "Hostname": "test",
+           |    "ExposedPorts": { "80/tcp": {}},
+           |    "Cmd": ["/bin", "/sh"],
+           |    "Image": "abc123",
+           |    "User": "root"
+           |  }
+           |}"""
+          .stripMargin
+          .decodeOption[Config]
+          .contains(
+            Config(
+              Config.Cfg(
+                Labels = Some(Map("test.one" -> "test one!", "test.two" -> "test two!")),
+                Hostname = Some("test"),
+                ExposedPorts = Some(Map("80/tcp" -> Map.empty)),
+                Cmd = Some(Vector("/bin", "/sh")),
+                Image = Some("abc123"),
+                User = Some("root")))))
+    }
+  }
+}

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import scala.util.Success
+import utest._
+
+object DockerRegistryTest extends TestSuite {
+  val tests = this{
+    "blobUrl" - {
+      assert(
+        DockerRegistry.blobUrl(
+          Image(
+            DockerDefaultRegistry,
+            DockerDefaultLibrary,
+            "alpine",
+            "3.5",
+            None,
+            None,
+            "alpine",
+            Some("3.5")), "abc123") == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
+    }
+
+    "manifestUrl" - {
+      assert(
+        DockerRegistry.manifestUrl(
+          Image(
+            DockerDefaultRegistry,
+            DockerDefaultLibrary,
+            "alpine",
+            "3.5",
+            None,
+            None,
+            "alpine",
+            Some("3.5"))) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
+    }
+
+    "parseImageUri" - {
+      assert(
+        DockerRegistry.parseImageUri("alpine") ==
+          Success(
+            Image(
+              DockerDefaultRegistry,
+              DockerDefaultLibrary,
+              "alpine",
+              "latest",
+              None,
+              None,
+              "alpine",
+              None)))
+
+      assert(
+        DockerRegistry.parseImageUri("alpine:3.5") ==
+          Success(
+            Image(
+              DockerDefaultRegistry,
+              DockerDefaultLibrary,
+              "alpine",
+              "3.5",
+              None,
+              None,
+              "alpine",
+              Some("3.5"))))
+
+      assert(
+        DockerRegistry.parseImageUri("lightbend-docker.registry.bintray.io/conductr/oci-in-docker") ==
+          Success(
+            Image(
+              "lightbend-docker.registry.bintray.io",
+              "conductr",
+              "oci-in-docker",
+              "latest",
+              Some("lightbend-docker.registry.bintray.io"),
+              Some("conductr"),
+              "oci-in-docker",
+              None)))
+
+      assert(
+        DockerRegistry.parseImageUri("lightbend-docker.registry.bintray.io/conductr/oci-in-docker:0.1") ==
+          Success(
+            Image(
+              "lightbend-docker.registry.bintray.io",
+              "conductr",
+              "oci-in-docker",
+              "0.1",
+              Some("lightbend-docker.registry.bintray.io"),
+              Some("conductr"),
+              "oci-in-docker",
+              Some("0.1"))))
+
+      assert(DockerRegistry.parseImageUri("").isFailure)
+      assert(DockerRegistry.parseImageUri("test:").isFailure)
+      assert(DockerRegistry.parseImageUri(":").isFailure)
+    }
+
+    "parseWwwAuthenticate" - {
+      val data = """Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:dockercloud/hello-world:pull""""
+
+      assert(DockerRegistry.parseWwwAuthenticate(data, "Bearer realm").contains("https://auth.docker.io/token"))
+      assert(DockerRegistry.parseWwwAuthenticate(data, "service").contains("registry.docker.io"))
+      assert(DockerRegistry.parseWwwAuthenticate(data, "scope").contains("repository:dockercloud/hello-world:pull"))
+      assert(DockerRegistry.parseWwwAuthenticate(data, "unknown").isEmpty)
+    }
+  }
+}

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/ManifestTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/ManifestTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import argonaut.Argonaut._
+import argonaut._
+import utest._
+
+object ManifestTest extends TestSuite {
+  val tests = this{
+    "Decode JSON" - {
+      "empty" - assert(
+        """{}""""
+          .decodeOption[Manifest]
+          .isEmpty)
+
+      "no layers" - assert(
+        """|{
+           |  "schemaVersion": 2,
+           |  "mediaType": "test",
+           |  "config": { "mediaType": "test", "size": 8192, "digest": "abc123" },
+           |  "layers": []
+           |}"""
+          .stripMargin
+          .decodeOption[Manifest]
+          .contains(Manifest(2, "test", Manifest.Layer("test", 8192, "abc123"), Vector.empty)))
+
+      assert(
+        """|{
+           |  "schemaVersion": 2,
+           |  "mediaType": "test2",
+           |  "config": { "mediaType": "test2", "size": 4096, "digest": "xyz456" },
+           |  "layers": [
+           |    { "mediaType": "test3", "size": 1, "digest": "oh" },
+           |    { "mediaType": "test4", "size": 2, "digest": "rly" }
+           |  ]
+           |}"""
+          .stripMargin
+          .decodeOption[Manifest]
+          .contains(
+            Manifest(
+              2,
+              "test2",
+              Manifest.Layer("test2", 4096, "xyz456"),
+              Vector(Manifest.Layer("test3", 1, "oh"), Manifest.Layer("test4", 2, "rly")))))
+    }
+  }
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpHeaders.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpHeaders.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+/**
+ * Container class for HTTP headers. Headers are case-insensitive. For example,
+ * `apply("Cache-Control")` will return the same value as `apply("cache-control")`.
+ * @param headers
+ */
+case class HttpHeaders(headers: Map[String, String]) {
+  private val lowerCaseHeaders =
+    headers
+      .keys
+      .map(h => toLowerCase(h) -> h)
+      .toMap
+
+  def apply(name: String): String = headers(lowerCaseHeaders(toLowerCase(name)))
+
+  def contains(name: String): Boolean =
+    lowerCaseHeaders.contains(toLowerCase(name))
+
+  def header(name: String): Option[String] =
+    for {
+      h <- lowerCaseHeaders.get(toLowerCase(name))
+      v <- headers.get(h)
+    } yield v
+
+  def updated(name: String, value: String): HttpHeaders =
+    copy(headers = headers.updated(headerName(name), value))
+
+  def remove(name: String): HttpHeaders =
+    copy(headers = headers - headerName(name))
+
+  private def headerName(name: String): String =
+    lowerCaseHeaders.getOrElse(toLowerCase(name), name)
+
+  private def toLowerCase(s: String): String = {
+    // FIXME replace with inlined .toLowerCase once https://github.com/scala-native/scala-native/pull/1037 merged
+
+    ("" + s).toLowerCase
+  }
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpRequest.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpRequest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+case class HttpRequest(
+  requestUrl: String,
+  requestMethod: String = "GET",
+  requestHeaders: HttpHeaders = HttpHeaders(Map.empty),
+  requestBody: Option[String] = None,
+  requestFollowRedirects: Boolean = false) {
+
+  def disableFollowRedirects: HttpRequest = copy(requestFollowRedirects = false)
+
+  def enableFollowRedirects: HttpRequest = copy(requestFollowRedirects = true)
+
+  def get: HttpRequest = copy(requestMethod = "GET")
+
+  def headers(headers: HttpHeaders): HttpRequest = copy(requestHeaders = headers)
+
+  def noContent: HttpRequest = copy(requestBody = None)
+
+  def post: HttpRequest = copy(requestMethod = "POST")
+
+  def url(url: String): HttpRequest = copy(requestUrl = url)
+
+  def withContent(body: String): HttpRequest = copy(requestBody = Some(body))
+
+  def withHeader(name: String, value: String): HttpRequest = copy(requestHeaders = requestHeaders.updated(name, value))
+
+  def withoutHeader(name: String): HttpRequest = copy(requestHeaders = requestHeaders.remove(name))
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpResponse.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpResponse.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+case class HttpResponse(statusCode: Long, headers: HttpHeaders, body: Option[String])

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/LibHttpSimple.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/LibHttpSimple.scala
@@ -24,10 +24,11 @@ object LibHttpSimple {
   private val CRLF = "\r\n"
   private val HttpHeaderAndBodyPartsSeparator = CRLF + CRLF
   private val HttpHeaderNameAndValueSeparator = ":"
+  private val MaxRedirects = 5
 
   case class InternalNativeFailure(errorCode: Long, errorDescription: String) extends RuntimeException(s"$errorCode: $errorDescription")
 
-  case class HttpResponse(statusCode: Long, headers: Map[String, String], body: Option[String])
+  case class InfiniteRedirect(visited: List[String]) extends RuntimeException(s"Infinte redirect detected: $visited")
 
   /**
    * Initializes libcurl` internal state by calling `curl_global_init` underneath.
@@ -51,25 +52,16 @@ object LibHttpSimple {
       nativebinding.httpsimple.global_cleanup()
     }
 
-  def get(url: String): Try[HttpResponse] =
-    doHttp("GET", url, headers = Map.empty, requestBody = None)
+  def apply(request: HttpRequest): Try[HttpResponse] =
+    doHttp(request.requestMethod, request.requestUrl, request.requestHeaders.headers, request.requestBody, request.requestFollowRedirects, Nil)
 
-  def get(url: String, headers: Map[String, String]): Try[HttpResponse] =
-    doHttp("GET", url, headers, requestBody = None)
-
-  def post(url: String): Try[HttpResponse] =
-    doHttp("POST", url, headers = Map.empty, requestBody = None)
-
-  def post(url: String, headers: Map[String, String]): Try[HttpResponse] =
-    doHttp("GET", url, headers, requestBody = None)
-
-  def post(url: String, headers: Map[String, String], requestBody: String): Try[HttpResponse] =
-    doHttp("GET", url, headers, requestBody = Some(requestBody))
-
-  def post(url: String, requestBody: String): Try[HttpResponse] =
-    doHttp("GET", url, headers = Map.empty, requestBody = Some(requestBody))
-
-  private def doHttp(method: String, url: String, headers: Map[String, String], requestBody: Option[String]): Try[HttpResponse] =
+  private def doHttp(
+    method: String,
+    url: String,
+    headers: Map[String, String],
+    requestBody: Option[String],
+    followRedirects: Boolean,
+    visitedUrls: List[String]): Try[HttpResponse] =
     native.Zone { implicit z =>
       val http_response_struct = nativebinding.httpsimple.do_http(
         native.toCString(method),
@@ -82,9 +74,19 @@ object LibHttpSimple {
         if (errorCode == 0) {
           val httpStatus = nativebinding.httpsimple.get_http_status(http_response_struct).cast[Long]
           val rawHttpResponse = native.fromCString(nativebinding.httpsimple.get_raw_http_response(http_response_struct))
-          val (header, body) = rawHttpResponseToHttpHeadersAndBody(rawHttpResponse)
+          val (headers, body) = rawHttpResponseToHttpHeadersAndBody(rawHttpResponse)
+          val hs = HttpHeaders(headers)
 
-          Success(HttpResponse(httpStatus, header, body))
+          if (followRedirects && httpStatus >= 300 && httpStatus <= 399 && hs.contains("Location")) {
+            val location = hs("Location")
+
+            if (visitedUrls.contains(location) || visitedUrls.length >= MaxRedirects)
+              Failure(InfiniteRedirect(visitedUrls))
+            else
+              doHttp("GET", location, Map.empty, None, true, location :: visitedUrls)
+          } else {
+            Success(HttpResponse(httpStatus, hs, body))
+          }
         } else {
           Failure(InternalNativeFailure(errorCode, errorMessageFromCode(errorCode)))
         }
@@ -114,9 +116,9 @@ object LibHttpSimple {
         val (headerText, responseBody) = splitBySeparator(rawResponse, HttpHeaderAndBodyPartsSeparator)
 
         // Exclude the first line which is the HTTP status line
-        val headers = headerText.split(CRLF).toList.tail.foldLeft(Map.empty[String, String]) { (v, l) =>
+        val headers = headerText.split(CRLF).tail.foldLeft(Map.empty[String, String]) { (v, l) =>
           val (headerName, headerValue) = splitBySeparator(l, HttpHeaderNameAndValueSeparator)
-          v + (headerName -> headerValue.trim)
+          v.updated(headerName, headerValue.trim)
         }
 
         headers -> Option(responseBody)

--- a/libhttpsimple/src/main/c/httpsimple.c
+++ b/libhttpsimple/src/main/c/httpsimple.c
@@ -28,10 +28,11 @@ struct http_response {
 int global_init() {
   CURLcode res_curl_code;
   res_curl_code = curl_global_init(CURL_GLOBAL_DEFAULT);
+
   if (res_curl_code == CURLE_OK) {
-    fprintf(stderr, "curl_global_init() failed: %s\n", curl_easy_strerror(res_curl_code));
     return 0;
   } else {
+    fprintf(stderr, "curl_global_init() failed: %s\n", curl_easy_strerror(res_curl_code));
     return -1;
   }
 }
@@ -77,7 +78,6 @@ struct http_response *do_http(char *http_method, char *url, char *request_header
     if(curl) {
       curl_easy_setopt(curl, CURLOPT_URL, url);
       curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, http_method);
-      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L); // Follow redirect
       curl_easy_setopt(curl, CURLOPT_HEADER, 1L); // Return header as part of the response text
 
       // Append request headers if defined


### PR DESCRIPTION
This PR implements a subset of the Docker Registry API to allow it to pull image manifests and configs from public registries. Thus, you can e.g. invoke DockerRegistry.getConfig("dockercloud/hello-world") and get back a Try[Config] containing details, including the labels where we store image annotations.

Part of this included removing `CURLOPT_FOLLOWLOCATION` and refactoring `LibHttpSimple` to use a Request class to build up details about a HTTP request. The redirection logic was moved into Scala code so that parsing of the response can be performed correctly. If the CURL feature is used, parsing of the request headers and body when redirects are performed becomes complicated as CURL doesn't have a way to separate the two requests, and thus `LibHttpSimple` receives both requests as one big string without any programmatic delineation.

This also implements logging via the slogging library. Log levels can be configured via the command line option `--loglevel`.

### TODO

- [x] scalaz to replace `someIf`
- [x] Condition for 3xx response to do redirect