### PR TITLE
Implement support for semantic version labels

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/annotations/Version.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/annotations/Version.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.annotations
+
+case class Version(major: Int, minor: Int, patch: Int, patchLabel: Option[String]) {
+  def version: String = s"$major.$minor.$patch${patchLabel.fold("")("-" + _)}"
+}

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -115,7 +115,8 @@ object AnnotationsTest extends TestSuite {
           privileged = false,
           healthCheck = None,
           readinessCheck = None,
-          environmentVariables = Map.empty))
+          environmentVariables = Map.empty,
+          version = None))
 
       "all options (except checks)" - {
         assert(
@@ -123,6 +124,10 @@ object AnnotationsTest extends TestSuite {
             "some.key" -> "test",
             "com.lightbend.rp.some-key" -> "test",
 
+            "com.lightbend.rp.version-major" -> "3",
+            "com.lightbend.rp.version-minor" -> "2",
+            "com.lightbend.rp.version-patch" -> "1",
+            "com.lightbend.rp.version-patch-label" -> "SNAPSHOT",
             "com.lightbend.rp.disk-space" -> "65536",
             "com.lightbend.rp.memory" -> "8192",
             "com.lightbend.rp.nr-of-cpus" -> "0.5",
@@ -183,7 +188,26 @@ object AnnotationsTest extends TestSuite {
             environmentVariables = Map(
               "testing1" -> LiteralEnvironmentVariable("testingvalue1"),
               "testing2" -> SecretEnvironmentVariable("secretvalue1"),
-              "testing3" -> kubernetes.ConfigMapEnvironmentVariable("mymap", "mykey"))))
+              "testing3" -> kubernetes.ConfigMapEnvironmentVariable("mymap", "mykey")),
+            version = Some(Version(3, 2, 1, Some("SNAPSHOT")))))
+      }
+
+      "version (no label)" - {
+        assert(
+          Annotations(Map(
+            "com.lightbend.rp.version-major" -> "3",
+            "com.lightbend.rp.version-minor" -> "2",
+            "com.lightbend.rp.version-patch" -> "1")) == Annotations(
+            diskSpace = None,
+            memory = None,
+            nrOfCpus = None,
+            endpoints = Map.empty,
+            volumes = Map.empty,
+            privileged = false,
+            healthCheck = None,
+            readinessCheck = None,
+            environmentVariables = Map.empty,
+            version = Some(Version(3, 2, 1, None))))
       }
 
       "CommandCheck" - {
@@ -203,7 +227,8 @@ object AnnotationsTest extends TestSuite {
             privileged = false,
             healthCheck = Some(CommandCheck("/usr/bin/env", "bash")),
             readinessCheck = Some(CommandCheck("/usr/bin/env", "bash")),
-            environmentVariables = Map.empty))
+            environmentVariables = Map.empty,
+            version = None))
       }
 
       "HttpCheck" - {
@@ -225,7 +250,8 @@ object AnnotationsTest extends TestSuite {
             privileged = false,
             healthCheck = Some(HttpCheck(0, "my-service", 5, "/hello")),
             readinessCheck = Some(HttpCheck(1234, "", 5, "/hello")),
-            environmentVariables = Map.empty))
+            environmentVariables = Map.empty,
+            version = None))
       }
 
       "TcpCheck" - {
@@ -245,7 +271,8 @@ object AnnotationsTest extends TestSuite {
             privileged = false,
             healthCheck = Some(TcpCheck(0, "my-service", 5)),
             readinessCheck = Some(TcpCheck(1234, "", 5)),
-            environmentVariables = Map.empty))
+            environmentVariables = Map.empty,
+            version = None))
       }
     }
   }

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/VersionTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/VersionTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.annotations
+
+import utest._
+
+object VersionTest extends TestSuite {
+  val tests = this{
+    "version" - {
+      assert(Version(3, 4, 5, None).version == "3.4.5")
+    }
+
+    "version (with label)" - {
+      assert(Version(6, 0, 0, Some("SNAPSHOT")).version == "6.0.0-SNAPSHOT")
+    }
+  }
+}


### PR DESCRIPTION
This implements support for parsing the semantic version labels stored in Docker labels, e.g.

```
LABEL com.lightbend.rp.version-major 1
LABEL com.lightbend.rp.version-minor 2
LABEL com.lightbend.rp.version-patch 3
LABEL com.lightbend.rp.version-patch-label SNAPSHOT
```

Relevant PR that produces these labels: https://github.com/typesafehub/sbt-reactive-app/pull/8